### PR TITLE
[FEATURE] Add possibility to configure via attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -56,13 +56,9 @@ final class FeatureFlagsPass implements CompilerPassInterface
                     ])
                 ;
 
-                $featureName = $tag['feature'];
-
-                if (null === $tag['feature'] || '' === $tag['feature']) {
-                    $featureName = $className;
-                    if ('__invoke' !== $method) {
-                        $featureName .= '::'.$method;
-                    }
+                $featureName = $tag['feature'] ?: $className;
+                if (array_key_exists($featureName, $features)) {
+                    throw new \RuntimeException(sprintf('Feature "%s" already defined in the "feature_flags.provider.lazy_in_memory" provider.', $featureName));
                 }
 
                 $features[$featureName] = new ServiceClosureArgument((new Definition(Feature::class))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Closure;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\FeatureFlags\Feature;
+use Symfony\Component\FeatureFlags\Strategy\CallbackStrategy;
+
+final class FeatureFlagsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $lazyInMemoryProvider = $container->getDefinition('feature_flags.provider.lazy_in_memory');
+
+        $features = $lazyInMemoryProvider->getArgument('$features');
+
+        foreach ($container->findTaggedServiceIds('feature_flags.self_feature_strategy') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $callback = (new Definition(Closure::class))
+                    ->setFactory([Closure::class, 'fromCallable'])
+                    ->setArguments([new Reference($serviceId), $tag['method']])
+                ;
+
+                $callbackDefinition = (new Definition(CallbackStrategy::class))
+                    ->addTag('feature_flags.feature_strategy')
+                    ->setArguments([
+                        $callback
+                    ])
+                ;
+
+                $features[$tag['feature']] = new ServiceClosureArgument((new Definition(Feature::class))
+                    ->setShared(false)
+                    ->setArguments([
+                        $tag['feature'],
+                        '',
+                        $tag['default'],
+                        $callbackDefinition,
+                    ]))
+                ;
+            }
+        }
+
+        $lazyInMemoryProvider->setArgument('$features', $features);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -1,6 +1,13 @@
 <?php
 
-declare(strict_types=1);
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Closure;
-use LogicException;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -35,7 +34,7 @@ final class FeatureFlagsPass implements CompilerPassInterface
                 $method = $tag['method'] ?? '__invoke';
 
                 if (!$r->hasMethod($method)) {
-                    throw new \RuntimeException(sprintf('Invalid feature "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
+                    throw new \RuntimeException(sprintf('Invalid feature strategy "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
                 }
 
                 $callback = (new Definition(Closure::class))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -60,13 +60,15 @@ final class FeatureFlagsPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('Feature "%s" already defined in the "feature_flags.provider.lazy_in_memory" provider.', $featureName));
                 }
 
+                $container->setDefinition($callbackDefinitionId = "feature_flags.callback_strategy.{$featureName}", $callbackDefinition);
+
                 $features[$featureName] = new ServiceClosureArgument((new Definition(Feature::class))
                     ->setShared(false)
                     ->setArguments([
                         $featureName,
                         $tag['description'] ?? '',
                         $tag['default'] ?? false,
-                        $callbackDefinition,
+                        new Reference($callbackDefinitionId),
                     ])
                 );
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\FeatureFlags\Strategy\CallbackStrategy;
 
 final class FeatureFlagsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('feature_flags.provider.lazy_in_memory')) {
             return;
@@ -55,7 +55,7 @@ final class FeatureFlagsPass implements CompilerPassInterface
                     ])
                 ;
 
-                $featureName = $tag['feature'] ?: $className;
+                $featureName = ($tag['feature'] ?? '') ?: $className;
                 if (array_key_exists($featureName, $features)) {
                     throw new \RuntimeException(sprintf('Feature "%s" already defined in the "feature_flags.provider.lazy_in_memory" provider.', $featureName));
                 }
@@ -67,8 +67,8 @@ final class FeatureFlagsPass implements CompilerPassInterface
                         $tag['description'] ?? '',
                         $tag['default'] ?? false,
                         $callbackDefinition,
-                    ]))
-                ;
+                    ])
+                );
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Closure;
+use LogicException;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -17,15 +19,28 @@ final class FeatureFlagsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('feature_flags.provider.lazy_in_memory')) {
+            return;
+        }
+
         $lazyInMemoryProvider = $container->getDefinition('feature_flags.provider.lazy_in_memory');
 
         $features = $lazyInMemoryProvider->getArgument('$features');
 
         foreach ($container->findTaggedServiceIds('feature_flags.self_feature_strategy') as $serviceId => $tags) {
+            $className = $this->getServiceClass($container, $serviceId);
+            $r = $container->getReflectionClass($className);
+
             foreach ($tags as $tag) {
+                $method = $tag['method'] ?? '__invoke';
+
+                if (!$r->hasMethod($method)) {
+                    throw new \RuntimeException(sprintf('Invalid feature "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
+                }
+
                 $callback = (new Definition(Closure::class))
                     ->setFactory([Closure::class, 'fromCallable'])
-                    ->setArguments([[new Reference($serviceId), $tag['method']]])
+                    ->setArguments([[new Reference($serviceId), $method]])
                 ;
 
                 $callbackDefinition = (new Definition(CallbackStrategy::class))
@@ -35,12 +50,21 @@ final class FeatureFlagsPass implements CompilerPassInterface
                     ])
                 ;
 
-                $features[$tag['feature']] = new ServiceClosureArgument((new Definition(Feature::class))
+                $featureName = $tag['feature'];
+
+                if (null === $tag['feature'] || '' === $tag['feature']) {
+                    $featureName = $className;
+                    if ('__invoke' !== $method) {
+                        $featureName .= '::'.$method;
+                    }
+                }
+
+                $features[$featureName] = new ServiceClosureArgument((new Definition(Feature::class))
                     ->setShared(false)
                     ->setArguments([
-                        $tag['feature'],
-                        '',
-                        $tag['default'],
+                        $featureName,
+                        $tag['description'] ?? '',
+                        $tag['default'] ?? false,
                         $callbackDefinition,
                     ]))
                 ;
@@ -48,5 +72,20 @@ final class FeatureFlagsPass implements CompilerPassInterface
         }
 
         $lazyInMemoryProvider->setArgument('$features', $features);
+    }
+
+    private function getServiceClass(ContainerBuilder $container, string $serviceId): string
+    {
+        while (true) {
+            $definition = $container->findDefinition($serviceId);
+
+            if (!$definition->getClass() && $definition instanceof ChildDefinition) {
+                $serviceId = $definition->getParent();
+
+                continue;
+            }
+
+            return $definition->getClass();
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\FeatureFlags\Feature;
 use Symfony\Component\FeatureFlags\Strategy\CallbackStrategy;
@@ -35,6 +36,10 @@ final class FeatureFlagsPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('feature_flags.self_feature_strategy') as $serviceId => $tags) {
             $className = $this->getServiceClass($container, $serviceId);
             $r = $container->getReflectionClass($className);
+
+            if (null === $r) {
+                throw new RuntimeException(sprintf('Invalid service "%s": class "%s" does not exist.', $serviceId, $className));
+            }
 
             foreach ($tags as $tag) {
                 $method = $tag['method'] ?? '__invoke';
@@ -77,7 +82,7 @@ final class FeatureFlagsPass implements CompilerPassInterface
         $lazyInMemoryProvider->setArgument('$features', $features);
     }
 
-    private function getServiceClass(ContainerBuilder $container, string $serviceId): string
+    private function getServiceClass(ContainerBuilder $container, string $serviceId): string|null
     {
         while (true) {
             $definition = $container->findDefinition($serviceId);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
-use Closure;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -44,8 +43,8 @@ final class FeatureFlagsPass implements CompilerPassInterface
                     throw new \RuntimeException(sprintf('Invalid feature strategy "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
                 }
 
-                $callback = (new Definition(Closure::class))
-                    ->setFactory([Closure::class, 'fromCallable'])
+                $callback = (new Definition(\Closure::class))
+                    ->setFactory([\Closure::class, 'fromCallable'])
                     ->setArguments([[new Reference($serviceId), $method]])
                 ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagsPass.php
@@ -25,7 +25,7 @@ final class FeatureFlagsPass implements CompilerPassInterface
             foreach ($tags as $tag) {
                 $callback = (new Definition(Closure::class))
                     ->setFactory([Closure::class, 'fromCallable'])
-                    ->setArguments([new Reference($serviceId), $tag['method']])
+                    ->setArguments([[new Reference($serviceId), $tag['method']]])
                 ;
 
                 $callbackDefinition = (new Definition(CallbackStrategy::class))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -50,6 +50,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'event_dispatcher.dispatcher',
         'feature_flags.feature_provider',
         'feature_flags.feature_strategy',
+        'feature_flags.self_feature_strategy',
         'form.type',
         'form.type_extension',
         'form.type_guesser',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -196,6 +196,7 @@ use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use function array_merge;
+use function sprintf;
 
 /**
  * Process the configuration and prepare the dependency injection container with
@@ -3018,8 +3019,8 @@ class FrameworkExtension extends Extension
                 if ($reflector instanceof ReflectionClass) {
                     $method = $attribute->method ?? '__invoke';
                 } else {
-                    if (null !== $attribute->method) {
-                        throw new \LogicException('It doesn\'t make sense.');
+                    if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {
+                        throw new \LogicException(sprintf('Using the #[%s(method: %s)] attribute on a method is not valid. Either remove the method value or move this to the top of the class (%s)', AsStrategy::class, $attribute->method, $reflector->getDeclaringClass()->getNamespaceName().$reflector->getDeclaringClass()->getName()));
                     }
 
                     $method = $reflector->getName();
@@ -3028,7 +3029,6 @@ class FrameworkExtension extends Extension
                 $definition->addTag('feature_flags.self_feature_strategy', [
                     'feature' => $attribute->feature,
                     'description' => $attribute->description,
-                    'default' => false,
                     'method' => $method,
                 ]);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -23,7 +23,6 @@ use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
-use ReflectionClass;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -195,8 +194,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
-use function array_merge;
-use function sprintf;
 
 /**
  * Process the configuration and prepare the dependency injection container with
@@ -3016,7 +3013,7 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
-                if ($reflector instanceof ReflectionClass) {
+                if ($reflector instanceof \ReflectionClass) {
                     $method = $attribute->method ?? '__invoke';
                 } else {
                     if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3015,11 +3015,21 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+                if ($reflector instanceof ReflectionClass) {
+                    $method = $attribute->method ?? '__invoke';
+                } else {
+                    if (null !== $attribute->method) {
+                        throw new \LogicException('It doesn\'t make sense.');
+                    }
+
+                    $method = $reflector->getName();
+                }
+
                 $definition->addTag('feature_flags.self_feature_strategy', [
                     'feature' => $attribute->feature,
                     'description' => $attribute->description,
                     'default' => false,
-                    'method' => $reflector instanceof ReflectionClass ? '__invoke' : $reflector->getName(),
+                    'method' => $method,
                 ]);
             }
         );

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3015,21 +3015,11 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
-                if ($reflector instanceof ReflectionClass) {
-                    if (!$reflector->hasMethod('__invoke')) {
-                        throw new \LogicException('Wrong');
-                    }
-
-                    $callbackMethod = '__invoke';
-                } else {
-                    $callbackMethod = $reflector->getName();
-                }
-
                 $definition->addTag('feature_flags.self_feature_strategy', [
                     'feature' => $attribute->feature,
                     'description' => $attribute->description,
-                    'default' => $attribute->default,
-                    'method' => $callbackMethod,
+                    'default' => false,
+                    'method' => $reflector instanceof ReflectionClass ? '__invoke' : $reflector->getName(),
                 ]);
             }
         );

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3013,9 +3013,13 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+                $featureName = $attribute->feature;
+
                 if ($reflector instanceof \ReflectionClass) {
                     $className = $reflector->getName();
                     $method = $attribute->method;
+
+                    $featureName ??= $className;
                 } else {
                     $className = $reflector->getDeclaringClass()->getName();
                     if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {
@@ -3023,10 +3027,11 @@ class FrameworkExtension extends Extension
                     }
 
                     $method = $reflector->getName();
+                    $featureName ??= "{$className}::{$method}";
                 }
 
                 $definition->addTag('feature_flags.self_feature_strategy', [
-                    'feature' => $attribute->feature ?? $className,
+                    'feature' => $featureName,
                     'description' => $attribute->description,
                     'method' => $method,
                 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3014,10 +3014,10 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
                 if ($reflector instanceof \ReflectionClass) {
-                    $className = $reflector->getNamespaceName() . $reflector->getName();
+                    $className = $reflector->getName();
                     $method = $attribute->method;
                 } else {
-                    $className = $reflector->getDeclaringClass()->getNamespaceName().$reflector->getDeclaringClass()->getName();
+                    $className = $reflector->getDeclaringClass()->getName();
                     if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {
                         throw new \LogicException(sprintf('Using the #[%s(method: %s)] attribute on a method is not valid. Either remove the method value or move this to the top of the class (%s)', AsStrategy::class, $attribute->method, $className));
                     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
-use Closure;
 use Composer\InstalledVersions;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -25,10 +24,8 @@ use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
 use ReflectionClass;
-use ReflectionMethod;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
-use Symfony\Bundle\FeatureFlagsBundle\Strategy\CustomStrategy;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Bundle\FullStack;
@@ -78,7 +75,6 @@ use Symfony\Component\FeatureFlags\Attribute\AsStrategy;
 use Symfony\Component\FeatureFlags\Feature;
 use Symfony\Component\FeatureFlags\FeatureChecker;
 use Symfony\Component\FeatureFlags\Provider\ProviderInterface;
-use Symfony\Component\FeatureFlags\Strategy\CallbackStrategy;
 use Symfony\Component\FeatureFlags\Strategy\StrategyInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
@@ -3009,7 +3005,7 @@ class FrameworkExtension extends Extension
                 ]))
             ;
         }
-        $lazyInMemoryProvider = $container->getDefinition('feature_flags.provider.lazy_in_memory')
+        $container->getDefinition('feature_flags.provider.lazy_in_memory')
             ->setArgument('$features', $features)
         ;
 
@@ -3018,7 +3014,7 @@ class FrameworkExtension extends Extension
         ;
 
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
-            static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector) use (&$lazyInMemoryProvider): void {
+            static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
                 if ($reflector instanceof ReflectionClass) {
                     if (!$reflector->hasMethod('__invoke')) {
                         throw new \LogicException('Wrong');
@@ -3029,34 +3025,11 @@ class FrameworkExtension extends Extension
                     $callbackMethod = $reflector->getName();
                 }
 
-                $callback = (new Definition(Closure::class))
-                    ->setFactory([Closure::class, 'fromCallable'])
-                    ->setArguments([$definition, $callbackMethod])
-                ;
-
-                $callbackDefinition = (new Definition(CallbackStrategy::class))
-                    ->addTag('feature_flags.feature_strategy')
-                    ->setArguments([
-                        $callback
-                    ])
-                ;
-
                 $definition->addTag('feature_flags.self_feature_strategy', [
                     'feature' => $attribute->feature,
                     'default' => $attribute->default,
                     'method' => $callbackMethod,
                 ]);
-
-//                $lazyInMemoryProvider->setArgument('$features', array_merge($lazyInMemoryProvider->getArgument('$features'), [
-//                    $attribute->feature => new ServiceClosureArgument((new Definition(Feature::class))
-//                        ->setShared(false)
-//                        ->setArguments([
-//                            $attribute->feature,
-//                            '',
-//                            $attribute->default,
-//                            $callbackDefinition,
-//                        ])),
-//                ]));
             }
         );
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3014,17 +3014,19 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsStrategy::class,
             static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
                 if ($reflector instanceof \ReflectionClass) {
-                    $method = $attribute->method ?? '__invoke';
+                    $className = $reflector->getNamespaceName() . $reflector->getName();
+                    $method = $attribute->method;
                 } else {
+                    $className = $reflector->getDeclaringClass()->getNamespaceName().$reflector->getDeclaringClass()->getName();
                     if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {
-                        throw new \LogicException(sprintf('Using the #[%s(method: %s)] attribute on a method is not valid. Either remove the method value or move this to the top of the class (%s)', AsStrategy::class, $attribute->method, $reflector->getDeclaringClass()->getNamespaceName().$reflector->getDeclaringClass()->getName()));
+                        throw new \LogicException(sprintf('Using the #[%s(method: %s)] attribute on a method is not valid. Either remove the method value or move this to the top of the class (%s)', AsStrategy::class, $attribute->method, $className));
                     }
 
                     $method = $reflector->getName();
                 }
 
                 $definition->addTag('feature_flags.self_feature_strategy', [
-                    'feature' => $attribute->feature,
+                    'feature' => $attribute->feature ?? $className,
                     'description' => $attribute->description,
                     'method' => $method,
                 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3027,6 +3027,7 @@ class FrameworkExtension extends Extension
 
                 $definition->addTag('feature_flags.self_feature_strategy', [
                     'feature' => $attribute->feature,
+                    'description' => $attribute->description,
                     'default' => $attribute->default,
                     'method' => $callbackMethod,
                 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
+use Closure;
 use Composer\InstalledVersions;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -23,6 +24,8 @@ use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
+use ReflectionClass;
+use ReflectionMethod;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FeatureFlagsBundle\Strategy\CustomStrategy;
@@ -71,9 +74,11 @@ use Symfony\Component\Dotenv\Command\DebugCommand;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\FeatureFlags\Attribute\AsStrategy;
 use Symfony\Component\FeatureFlags\Feature;
 use Symfony\Component\FeatureFlags\FeatureChecker;
 use Symfony\Component\FeatureFlags\Provider\ProviderInterface;
+use Symfony\Component\FeatureFlags\Strategy\CallbackStrategy;
 use Symfony\Component\FeatureFlags\Strategy\StrategyInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
@@ -194,6 +199,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
+use function array_merge;
 
 /**
  * Process the configuration and prepare the dependency injection container with
@@ -3003,13 +3009,56 @@ class FrameworkExtension extends Extension
                 ]))
             ;
         }
-        $container->getDefinition('feature_flags.provider.lazy_in_memory')
+        $lazyInMemoryProvider = $container->getDefinition('feature_flags.provider.lazy_in_memory')
             ->setArgument('$features', $features)
         ;
 
         $container->registerForAutoconfiguration(StrategyInterface::class)
             ->addTag('feature_flags.feature_strategy')
         ;
+
+        $container->registerAttributeForAutoconfiguration(AsStrategy::class,
+            static function (ChildDefinition $definition, AsStrategy $attribute, \ReflectionClass|\ReflectionMethod $reflector) use (&$lazyInMemoryProvider): void {
+                if ($reflector instanceof ReflectionClass) {
+                    if (!$reflector->hasMethod('__invoke')) {
+                        throw new \LogicException('Wrong');
+                    }
+
+                    $callbackMethod = '__invoke';
+                } else {
+                    $callbackMethod = $reflector->getName();
+                }
+
+                $callback = (new Definition(Closure::class))
+                    ->setFactory([Closure::class, 'fromCallable'])
+                    ->setArguments([$definition, $callbackMethod])
+                ;
+
+                $callbackDefinition = (new Definition(CallbackStrategy::class))
+                    ->addTag('feature_flags.feature_strategy')
+                    ->setArguments([
+                        $callback
+                    ])
+                ;
+
+                $definition->addTag('feature_flags.self_feature_strategy', [
+                    'feature' => $attribute->feature,
+                    'default' => $attribute->default,
+                    'method' => $callbackMethod,
+                ]);
+
+//                $lazyInMemoryProvider->setArgument('$features', array_merge($lazyInMemoryProvider->getArgument('$features'), [
+//                    $attribute->feature => new ServiceClosureArgument((new Definition(Feature::class))
+//                        ->setShared(false)
+//                        ->setArguments([
+//                            $attribute->feature,
+//                            '',
+//                            $attribute->default,
+//                            $callbackDefinition,
+//                        ])),
+//                ]));
+            }
+        );
 
         foreach ($config['strategies'] as $strategyName => $strategyConfig) {
             ['type' => $type, 'with' => $with] = $strategyConfig;

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilder
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FeatureFlagsDebugPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FeatureFlagsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
@@ -178,6 +179,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new ErrorLoggerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
 
         if ($container->getParameter('kernel.debug')) {
+            $container->addCompilerPass(new FeatureFlagsPass());
             $container->addCompilerPass(new FeatureFlagsDebugPass());
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -177,9 +177,9 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
         // must be registered after MonologBundle's LoggerChannelPass
         $container->addCompilerPass(new ErrorLoggerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
+        $container->addCompilerPass(new FeatureFlagsPass());
 
         if ($container->getParameter('kernel.debug')) {
-            $container->addCompilerPass(new FeatureFlagsPass());
             $container->addCompilerPass(new FeatureFlagsDebugPass());
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
@@ -10,7 +10,6 @@ final class AsStrategy
     public function __construct(
         public readonly string|null $feature = null,
         public readonly string|null $description = null,
-        public readonly bool $default = false,
     ) {
     }
 }

--- a/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
@@ -8,7 +8,8 @@ namespace Symfony\Component\FeatureFlags\Attribute;
 final class AsStrategy
 {
     public function __construct(
-        public readonly string $feature,
+        public readonly string|null $feature = null,
+        public readonly string|null $description = null,
         public readonly bool $default = false,
     ) {
     }

--- a/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\FeatureFlags\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class AsStrategy
+{
+    public function __construct(
+        public readonly string $feature,
+        public readonly bool $default = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
@@ -1,6 +1,13 @@
 <?php
 
-declare(strict_types=1);
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Symfony\Component\FeatureFlags\Attribute;
 

--- a/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Attribute/AsStrategy.php
@@ -10,6 +10,7 @@ final class AsStrategy
     public function __construct(
         public readonly string|null $feature = null,
         public readonly string|null $description = null,
+        public readonly string|null $method = null,
     ) {
     }
 }

--- a/src/Symfony/Component/FeatureFlags/CHANGELOG.md
+++ b/src/Symfony/Component/FeatureFlags/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.1
+---
+
+ * Add the component as experimental

--- a/src/Symfony/Component/FeatureFlags/README.md
+++ b/src/Symfony/Component/FeatureFlags/README.md
@@ -71,7 +71,7 @@ Available strategies
 Resources
 ---------
 
-* [Contributing](https://symfony.com/doc/current/contributing/index.html)
-* [Report issues](https://github.com/symfony/symfony/issues) and
-  [send Pull Requests](https://github.com/symfony/symfony/pulls)
-  in the [main Symfony repository](https://github.com/symfony/symfony)
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\FeatureFlags\Strategy;
 
 use Closure;
 use Symfony\Component\FeatureFlags\StrategyResult;
-use function is_bool;
 
 final class CallbackStrategy implements StrategyInterface
 {
@@ -37,6 +36,6 @@ final class CallbackStrategy implements StrategyInterface
             return $innerResult;
         }
 
-        // TODO : LogicExcepiton
+        throw new \LogicException(sprintf('The inner Closure must return a bool or a "%s". "%s" returned.', StrategyResult::class, get_debug_type($innerResult)));
     }
 }

--- a/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
@@ -18,7 +18,7 @@ use function is_bool;
 final class CallbackStrategy implements StrategyInterface
 {
     /**
-     * @param (Closure(): bool|StrategyResult) $inner
+     * @param Closure(): (bool|StrategyResult) $inner
      */
     public function __construct(
         private readonly Closure $inner,
@@ -37,6 +37,6 @@ final class CallbackStrategy implements StrategyInterface
             return $innerResult;
         }
 
-        // LogicExcepiton
+        // TODO : LogicExcepiton
     }
 }

--- a/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
+++ b/src/Symfony/Component/FeatureFlags/Strategy/CallbackStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlags\Strategy;
+
+use Closure;
+use Symfony\Component\FeatureFlags\StrategyResult;
+use function is_bool;
+
+final class CallbackStrategy implements StrategyInterface
+{
+    /**
+     * @param (Closure(): bool|StrategyResult) $inner
+     */
+    public function __construct(
+        private readonly Closure $inner,
+    ) {
+    }
+
+    public function compute(): StrategyResult
+    {
+        $innerResult = ($this->inner)();
+
+        if (is_bool($innerResult)) {
+            return $innerResult === true ? StrategyResult::Grant : StrategyResult::Deny;
+        }
+
+        if ($innerResult instanceof StrategyResult) {
+            return $innerResult;
+        }
+
+        // LogicExcepiton
+    }
+}


### PR DESCRIPTION
Using PHP Attributes to easily configure both the feature names and the strategy associated when you want a simple logic.

Here is how it work

**On a service class**

```php
<?php

declare(strict_types=1);

namespace App;

use Symfony\Component\FeatureFlags\Attribute\AsStrategy;

#[AsStrategy(feature: 'my_feature_1')] // Will call the `__invoke` method
#[AsStrategy(feature: 'my_feature_2', method: 'someMethod')] // Will call the `someMethod` method
#[AsStrategy()] // equivalent to #[AsStrategy(feature: MyFeatureStrategy::class)] and will call the `__invoke` method
final class MyFeatureStrategy
{
    public function __invoke(): bool
    {
        // do some logic
    }

    public function someMethod()
    {
        // do some logic
    }
}
```

**On any method within a service class**

```php
<?php

declare(strict_types=1);

namespace App;

use Symfony\Component\FeatureFlags\Attribute\AsStrategy;

final class MyFeatureStrategy
{
    #[AsStrategy(feature: 'my_other_feature_1')]
    public function someMethod()
    {
        // do some logic
    }

    #[AsStrategy()]  // equivalent to #[AsStrategy(feature: MyFeatureStrategy::class)]
    public function someOtherMethod()
    {
        // do some logic
    }
}
```

If you used without the `feature` argument then you can reference the feature by its FQCN like so :
```php
use Symfony\Component\FeatureFlags\FeatureCheckerInterface;

class MyService
{
    public function __construct(private FeatureCheckerInterface $featureChecker) {}

    public function doSomething()
    {
        if ($this->featureChecker->isEnabled(\App\MyFeatureStrategy::class)) {
            // do stuff
        }
    }
}
```